### PR TITLE
Register coin count dynamically

### DIFF
--- a/TreasureHunters/Scripts/Coin.gd
+++ b/TreasureHunters/Scripts/Coin.gd
@@ -11,21 +11,29 @@ func _on_Coin_body_entered(body):
 	if body.name == "Adventurer" and self.visible == true:
 		Global.audio_players["CoinCollection"].play()
 		
+		var coin_idx = int(self.name.right(4)) - 1
+		Global.coins[coin_idx] = false
+		
+		# We can't queue_free because the collected_coin needs to finish animating first
+		# Instead, make this coin invisible
+		self.visible = false
+		
 		var collected_coin: Control = load("res://Scenes/Items/CollectedCoin.tscn").instance()
 		collected_coin.rect_global_position = self.get_global_transform_with_canvas().get_origin()
 		collected_coin.rect_scale = $Sprite.transform.get_scale()
+		
+		collected_coin.connect("tree_exiting", self, "_register_coin_and_exit")
 
 		self.gameplay_interface.add_child(collected_coin)
-		
 		collected_coin.animate()
-		register_coin()
-		queue_free()
+		
 
-func register_coin():
-	
+func _register_coin_and_exit():
 	Global.coins_total += 1
 	Global.coins_collected_total += 1
-	var coin_idx = int(self.name.right(4)) - 1
 	Global.coins_collected_level += 1
-	Global.coins[coin_idx] = false
+	
+	queue_free()
+	
+	
 	

--- a/TreasureHunters/Scripts/Treasure.gd
+++ b/TreasureHunters/Scripts/Treasure.gd
@@ -27,10 +27,9 @@ func _process(delta):
 
 func _on_chest_opened():
 	Global.audio_players["TreasureCollection"].play(0)
-	register_chest()
+	Global.chests[chest_idx] = false
 	
 	for i in range(self.coins_in_chest):
-		
 		var collected_coin: Control = load("res://Scenes/Items/CollectedCoin.tscn").instance()
 		
 		var coin_sprite: AnimatedSprite = collected_coin.get_node("CoinSprite")
@@ -44,15 +43,19 @@ func _on_chest_opened():
 		self.gameplay_interface.add_child(collected_coin)
 		collected_coin.animate()
 		
+		# Increment coin count when the coin exits the tree (i.e. when it reaches the coin count HUD)
+		collected_coin.connect("tree_exiting", self, "_increment_coin_counts")
+		
+		# Stagger coin animations to create a "stream" of coins
 		yield(get_tree().create_timer(.05), "timeout")
 	
 
-func register_chest():
+func _increment_coin_counts():
+	Global.coins_total += 1
+	Global.coins_collected_total += 1
+	Global.coins_collected_level += 1
 	
-	Global.coins_total += self.coins_in_chest
-	Global.coins_collected_total += self.coins_in_chest
-	Global.coins_collected_level += self.coins_in_chest
-	Global.chests[chest_idx] = false
+	
 	
 func _on_Area2D_body_entered(body):
 	


### PR DESCRIPTION
### Summary

I changed the "register_coin" feature, so that the coin total isn't updated until the coin flies up and joins with the coin total's display. It's subtle for a single coin, but more pronounced for the treasure, so that you can see the coin total incrementing one by one rather than all at once.